### PR TITLE
Handle OpenAI failures with fallback embedding

### DIFF
--- a/manual_rag_bot/README.md
+++ b/manual_rag_bot/README.md
@@ -14,6 +14,8 @@
    OpenAI API キーは `OPENAI_API_KEY` に指定してください。ChromaDB への接続先を
    変更したい場合は `CHROMA_HOST` と `CHROMA_PORT` を指定します (デフォルトは
    `chromadb:8000`)。
+   OpenAI API キーが未設定または API 利用上限に達している場合は、ハッシュ値を
+   用いた簡易埋め込みにフォールバックします。
 3. 依存パッケージをインストールします。
    ```bash
    pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- provide fallback embeddings when OpenAI requests fail or exceed quota
- log and return placeholder answer when ChatCompletion fails
- document fallback behaviour in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685254a11b7083258fec56367bad4ef2