### PR TITLE
Fix OpenAI model configuration

### DIFF
--- a/manual_rag_bot/.env.example
+++ b/manual_rag_bot/.env.example
@@ -1,4 +1,5 @@
 OPENAI_API_KEY=your-openai-key
+OPENAI_MODEL=gpt-3.5-turbo
 SECRET_KEY=change-me
 DEBUG=True
 ALLOWED_HOSTS=localhost,127.0.0.1

--- a/manual_rag_bot/README.md
+++ b/manual_rag_bot/README.md
@@ -14,6 +14,8 @@
    OpenAI API キーは `OPENAI_API_KEY` に指定してください。ChromaDB への接続先を
    変更したい場合は `CHROMA_HOST` と `CHROMA_PORT` を指定します (デフォルトは
    `chromadb:8000`)。
+   利用する ChatGPT モデルを変更したい場合は `OPENAI_MODEL` にモデル名を設定でき
+   ます (デフォルトは `gpt-3.5-turbo`)。
    OpenAI API キーが未設定または API 利用上限に達している場合は、ハッシュ値を
    用いた簡易埋め込みにフォールバックします。
 3. 依存パッケージをインストールします。

--- a/manual_rag_bot/rag_app/services/openai_service.py
+++ b/manual_rag_bot/rag_app/services/openai_service.py
@@ -4,6 +4,8 @@ import hashlib
 import logging
 import openai
 
+_MODEL_NAME = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+
 _CLIENT = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 
@@ -48,7 +50,7 @@ def ask_openai(prompt: str) -> str:
 
     try:
         response = _CLIENT.chat.completions.create(
-            model="gpt-4",
+            model=_MODEL_NAME,
             messages=[
                 {"role": "system", "content": "あなたは親切なアシスタントです。"},
                 {"role": "user", "content": prompt},


### PR DESCRIPTION
## Summary
- allow specifying the chat model via `OPENAI_MODEL` environment variable
- default to `gpt-3.5-turbo`
- document the new variable in README and `.env.example`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68525a64de948325a78d4c0398bbbbb9