### PR TITLE
Fix fallback when OpenAI key missing

### DIFF
--- a/manual_rag_bot/README.md
+++ b/manual_rag_bot/README.md
@@ -16,8 +16,9 @@
    `chromadb:8000`)。
    利用する ChatGPT モデルを変更したい場合は `OPENAI_MODEL` にモデル名を設定でき
    ます (デフォルトは `gpt-3.5-turbo`)。
-   OpenAI API キーが未設定または API 利用上限に達している場合は、ハッシュ値を
-   用いた簡易埋め込みにフォールバックします。
+   OpenAI API キーが未設定、または `.env` に記載されている
+   `your-openai-key` のままの場合や API 利用上限に達している場合は、
+   ハッシュ値を用いた簡易埋め込みにフォールバックします。
 3. 依存パッケージをインストールします。
    ```bash
    pip install -r requirements.txt

--- a/manual_rag_bot/rag_app/services/openai_service.py
+++ b/manual_rag_bot/rag_app/services/openai_service.py
@@ -14,7 +14,7 @@ class OpenAIEmbeddingFunction:
 
     def __call__(self, input: list[str]) -> list[list[float]]:
         if _no_api_key():
-            raise RuntimeError("OPENAI_API_KEY が設定されていません。")
+            return [simple_embedding(text) for text in input]
 
         try:
             res = _CLIENT.embeddings.create(
@@ -40,7 +40,7 @@ def simple_embedding(text: str, dim: int = 1536) -> list[float]:
 
 def _no_api_key() -> bool:
     """Return True if the OpenAI API key is not configured."""
-    return not _CLIENT.api_key
+    return not _CLIENT.api_key or _CLIENT.api_key == "your-openai-key"
 
 
 def ask_openai(prompt: str) -> str:
@@ -74,7 +74,7 @@ def ask_with_context(question: str, context: str) -> str:
 def create_embeddings(texts: list[str]) -> list[list[float]]:
     """Return embeddings for the provided texts."""
     if _no_api_key():
-        raise RuntimeError("OPENAI_API_KEY が設定されていません。")
+        return [simple_embedding(text) for text in texts]
 
     try:
         res = _CLIENT.embeddings.create(


### PR DESCRIPTION
## Summary
- avoid raising `RuntimeError` when `OPENAI_API_KEY` is not provided
- treat the placeholder `your-openai-key` as absent
- document fallback behaviour in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685264cef6bc8325b946b1be15ca3a79